### PR TITLE
Update media query from 500px to 575px and adjust dark/light mode switch positioning

### DIFF
--- a/assets/style/main.css
+++ b/assets/style/main.css
@@ -147,8 +147,8 @@ input[type="checkbox"]:checked ~ .todo-text{
 /* #region Dark Mode / Light Mode */
 .switch {
   position: absolute;
-  top: 25%;
-  right: 25%;
+  top: 20px;
+  right: 20px;
   display: inline-block;
   max-width: 60px;
   width: 100%;
@@ -195,7 +195,7 @@ input:checked + .slider:before {
 }
 /* #endregion */
 /* #region Responsive styles */
-@media(max-width: 500px) {
+@media(max-width: 575px) {
   html{
     font-size: 12pt;
   }
@@ -215,12 +215,12 @@ input:checked + .slider:before {
    }
    .switch {
   position: absolute;
-  top: 35%;
-  right: 9%;
+  top: 20px;
+  right: 5%;
   display: inline-block;
-  max-width: 60px;
+  max-width: 50px;
   width: 100%;
-  height: 34px;
+  height: 30px;
 }
 }
 /* #endregion */


### PR DESCRIPTION
# Changes Made

- Updated media query breakpoint from `max-width: 500px` to `max-width: 575px`
- Improved dark/light mode switch positioning for better consistency
- Reduced mobile switch size for better mobile UX
- Enhanced responsive behavior in the 550-600px range

# Files Modified
- `assets/style/main.css`



